### PR TITLE
Sort order and default attribute option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -204,9 +204,13 @@ We can also specify product options for select type attributes as so:
         - Yellow
         - Blue
         - Purple
-        - Pink
+        - Pink|default
         - Orange
 ```
+
+Use the marker `|default` to specify the default option. 
+
+Note that the order of the options in the config file determines the sort order of the options.
 
 Please note, certain attribute configurations follow certain rules so do ensure you're familiar with how Magento product attributes work in order to make best use of this component. An attribute's configuration elements are simply fields in the `catalog_eav_attribute` table with a few exceptions.
 

--- a/samples/components/attributes.yaml
+++ b/samples/components/attributes.yaml
@@ -16,7 +16,7 @@
         - Yellow
         - Blue
         - Purple
-        - Pink
+        - Pink|default
         - Orange
         - Brown
   - rrp:

--- a/src/app/code/community/Cti/Configurator/Helper/Components/Attributes.php
+++ b/src/app/code/community/Cti/Configurator/Helper/Components/Attributes.php
@@ -145,8 +145,8 @@ class Cti_Configurator_Helper_Components_Attributes extends Cti_Configurator_Hel
         // Ordered by position in YAML
         $optionsPosition = array_flip($options);
 
-        $toCreate = array_diff($options, array_keys($currentOptions));
-        $toDelete = array_diff(array_keys($currentOptions), $options);
+        $toCreate = array_values(array_diff($options, array_keys($currentOptions)));
+        $toDelete = array_values(array_diff(array_keys($currentOptions), $options));
 
         // Placeholders
         $value  = [];
@@ -179,7 +179,7 @@ class Cti_Configurator_Helper_Components_Attributes extends Cti_Configurator_Hel
                 "order"  => $order,
                 "delete" => $delete
             ],
-            "default" => [ $default ]
+            "default" => [ (in_array($default, $toCreate) ? self::NUMBER_MARKER . $default : $default) ]
         ];
 
         $attribute->addData($data);

--- a/src/app/code/community/Cti/Configurator/Helper/Components/Attributes.php
+++ b/src/app/code/community/Cti/Configurator/Helper/Components/Attributes.php
@@ -1,6 +1,9 @@
 <?php
 class Cti_Configurator_Helper_Components_Attributes extends Cti_Configurator_Helper_Components_Abstract {
 
+    const DEFAULT_MARKER = 'default';
+    const NUMBER_MARKER = '###';
+
     public function __construct() {
         $this->_componentName = 'attributes';
         $this->_filePath1 = Mage::getBaseDir().DS.'app'.DS.'etc'.DS.'components'.DS.'attributes.yaml';
@@ -72,6 +75,7 @@ class Cti_Configurator_Helper_Components_Attributes extends Cti_Configurator_Hel
         unset($value);
         $attribute->setEntityTypeId(Mage::getModel('eav/entity')->setType('catalog_product')->getTypeId());
         $attribute->setIsUserDefined(1);
+
         try {
             if ($canSave) {
                 $attribute->save();
@@ -84,7 +88,6 @@ class Cti_Configurator_Helper_Components_Attributes extends Cti_Configurator_Hel
             throw $e;
         }
     }
-
 
     /**
      * Gets a particular attribute otherwise
@@ -120,53 +123,68 @@ class Cti_Configurator_Helper_Components_Attributes extends Cti_Configurator_Hel
      * @param $attribute
      * @param $options
      */
-    private function _maintainAttributeOptions($attribute,$options) {
+    private function _maintainAttributeOptions($attribute, $options)
+    {
+        $currentOptions = array_filter($attribute->getSource()->getAllOptions(), function ($option) { return $option["label"] !== ""; });
 
-        $currentOptions = $attribute->getSource()->getAllOptions();
+        // Make label => id map of currentOptions
+        $currentOptions = array_combine(
+            array_map(function ($keys) { return $keys['label']; }, $currentOptions),
+            array_map(function ($keys) { return $keys['value']; }, $currentOptions)
+        );
 
-        $currentOptionFormat = array();
-        foreach ($currentOptions as $option) {
-            if ($option['label'] != '') {
-                $currentOptionFormat[] = $option['label'];
+        // Look for default marker
+        $default = null;
+        $options = array_map(function ($option) use (&$default, $currentOptions) {
+            if ($this->isDefault($option)) {
+                $default = $this->getOptionId($option, $currentOptions);
+            }
+            return $this->trimDefault($option);
+        }, $options);
+
+        // Ordered by position in YAML
+        $optionsPosition = array_flip($options);
+
+        $toCreate = array_diff($options, array_keys($currentOptions));
+        $toDelete = array_diff(array_keys($currentOptions), $options);
+
+        // Placeholders
+        $value  = [];
+        $order  = [];
+        $delete = [];
+
+        // All properties (value, order, delete) are set no matter the operation
+        $allOptions = array_unique(array_merge($options, array_keys($currentOptions)));
+        foreach ($allOptions as $option) {
+            $option_id = null;
+            if (in_array($option, $toCreate)) {
+                $option_id = is_numeric($option) ? self::NUMBER_MARKER . $option : $option;
+            } else {
+                $option_id = $currentOptions[$option];
+            }
+
+            $value[$option_id]  = [ 0 => $option ];
+            $order[$option_id]  = "" . isset($optionsPosition[$option]) ? $optionsPosition[$option] : "0";
+            $delete[$option_id] = "";
+
+            if (in_array($option, $toDelete, true)) {
+                $delete[$option_id] = "1"; // value of "1" means delete
             }
         }
 
-        $optionsToAdd = array_diff($options,$currentOptionFormat);
-        $optionsToRemove = array_diff($currentOptionFormat,$options);
+        // Data-structure derrived from saveAction in Mage_Adminhtml_Catalog_Product_AttributeController
+        $data = [
+            "option" => [
+                "value"  => $value,
+                "order"  => $order,
+                "delete" => $delete
+            ],
+            "default" => [ $default ]
+        ];
 
-        // Create new attributes
-        foreach ($optionsToAdd as $option) {
-
-            // Check if the option already exists
-            if (!$attribute->getSource()->getOptionId($option)) {
-
-                $attribute->setData(
-                    'option',
-                    array(
-                        'value'=>array(
-                            'option'=>array(
-                                $option
-                            )
-                        )
-                    )
-                );
-                $attribute->save();
-
-                $this->log($this->__("Created attribute option %s for %s",$option,$attribute->getAttributeCode()));
-            }
-        }
-
-        // Remove old attributes
-        foreach ($optionsToRemove as $option) {
-            $optionId = $attribute->getSource()->getOptionId($option);
-            $toDelete['delete'][$optionId] = true;
-            $toDelete['value'][$optionId] = true;
-            $setup = new Mage_Eav_Model_Entity_Setup('core_setup');
-            $setup->addAttributeOption($toDelete);
-            $this->log($this->__("Deleted attribute option %s for %s",$option,$attribute->getAttributeCode()));
-        }
+        $attribute->addData($data);
+        $attribute->save();
     }
-
 
     /**
      * @return array
@@ -199,5 +217,19 @@ class Cti_Configurator_Helper_Components_Attributes extends Cti_Configurator_Hel
             'frontend_input'            => 'boolean',
             'search_weight'             => 1 // EE only
         );
+    }
+
+    private function isDefault($option)
+    {
+        return strpos($option, "|" . self::DEFAULT_MARKER) !== false;
+    }
+    private function trimDefault($option)
+    {
+        return $this->isDefault($option) ? substr($option, 0, strpos($option, "|" . self::DEFAULT_MARKER)) : $option;
+    }
+    private function getOptionId($option, $currentOptions = [])
+    {
+        $option = $this->trimDefault($option);
+        return isset($currentOptions[$option]) ? $currentOptions[$option] : $option;
     }
 }


### PR DESCRIPTION
Added the option to specify a default attribute option for _select_ type (only):

    options:
      - S
      - M
      - L|default
      - XL

The old implementation would not take into account the sort order.

Additionally unified: insert, update, delete into one process